### PR TITLE
feat: preferencias + fix: fotos por usuario

### DIFF
--- a/angular/src/app/mi-perfil-personalizado/mi-perfil-personalizado.component.html
+++ b/angular/src/app/mi-perfil-personalizado/mi-perfil-personalizado.component.html
@@ -57,14 +57,14 @@
             <div class="flex items-center justify-between p-3 border border-gray-200 rounded bg-gray-50">
                 <span class="text-sm font-medium text-gray-700"> <i class="fa fa-bell text-blue-500 mr-2"></i> Pantalla</span>
                 <label class="relative inline-flex items-center cursor-pointer">
-                    <input type="checkbox" formControlName="notifyScreen" class="sr-only peer">
+                    <input type="checkbox" formControlName="notifyScreen" (change)="form.markAsDirty()" class="sr-only peer">
                     <div class="w-9 h-5 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-600"></div>
                 </label>
             </div>
             <div class="flex items-center justify-between p-3 border border-gray-200 rounded bg-gray-50">
                 <span class="text-sm font-medium text-gray-700"> <i class="fa fa-envelope text-yellow-500 mr-2"></i> Email</span>
                 <label class="relative inline-flex items-center cursor-pointer">
-                    <input type="checkbox" formControlName="notifyEmail" class="sr-only peer">
+                    <input type="checkbox" formControlName="notifyEmail" (change)="form.markAsDirty()" class="sr-only peer">
                     <div class="w-9 h-5 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-blue-600"></div>
                 </label>
             </div>
@@ -74,11 +74,11 @@
             <label class="block text-sm font-medium text-gray-700 mb-2">Frecuencia de envío</label>
             <div class="flex gap-4">
                 <label class="flex items-center cursor-pointer">
-                    <input type="radio" formControlName="notifyFrequency" value="immediate" class="text-blue-600 focus:ring-blue-500 border-gray-300">
+                    <input type="radio" formControlName="notifyFrequency" value="immediate" (change)="form.markAsDirty()" class="text-blue-600 focus:ring-blue-500 border-gray-300">
                     <span class="ml-2 text-sm text-gray-700">Inmediata</span>
                 </label>
                 <label class="flex items-center cursor-pointer">
-                    <input type="radio" formControlName="notifyFrequency" value="weekly" class="text-blue-600 focus:ring-blue-500 border-gray-300">
+                    <input type="radio" formControlName="notifyFrequency" value="weekly" (change)="form.markAsDirty()" class="text-blue-600 focus:ring-blue-500 border-gray-300">
                     <span class="ml-2 text-sm text-gray-700">Semanal</span>
                 </label>
             </div>
@@ -87,7 +87,7 @@
 
     <div class="pt-4">
       <button type="submit" 
-        [disabled]="(form.pristine && !archivoSeleccionado) || form.invalid || estaCargando()"
+        [disabled]="(form.pristine && !archivoSeleccionado) || estaCargando()"
         class="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex justify-center items-center gap-2">
           @if (estaCargando()) {
               <i class="fa fa-spinner fa-spin"></i> Guardando...

--- a/angular/src/app/mi-perfil-personalizado/mi-perfil-personalizado.component.ts
+++ b/angular/src/app/mi-perfil-personalizado/mi-perfil-personalizado.component.ts
@@ -2,8 +2,8 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RestService, ConfigStateService } from '@abp/ng.core';
 import { ToasterService } from '@abp/ng.theme.shared';
-import { FotoPerfilService } from '../services/foto-perfil.service';
 import { CommonModule } from '@angular/common';
+import { environment } from '../../environments/environment';
 import { ConfirmationService, Confirmation } from '@abp/ng.theme.shared';
 import { AuthService } from '@abp/ng.core';
 import { CuentaService } from '../proxy/cuentas/cuenta.service';
@@ -18,7 +18,6 @@ import { PreferenciasNotificacionService, FrecuenciaNotificacion } from '../prox
 export class MiPerfilPersonalizadoComponent implements OnInit {
   private fb = inject(FormBuilder);
   private rest = inject(RestService);
-  private fotoService = inject(FotoPerfilService);
   private toaster = inject(ToasterService);
   private configState = inject(ConfigStateService);
   private confirmation = inject(ConfirmationService); 
@@ -96,8 +95,9 @@ export class MiPerfilPersonalizadoComponent implements OnInit {
 
   actualizarUrlImagen() {
     if (this.usuarioId) {
-        // Timestamp para evitar caché del navegador
-        this.urlImagen = `${this.fotoService.obtenerUrlFoto(this.usuarioId)}?t=${new Date().getTime()}`;
+        // URL completa del backend con timestamp para evitar caché
+        const apiUrl = environment.apis.default.url;
+        this.urlImagen = `${apiUrl}/api/app/foto-perfil/obtener/${this.usuarioId}?t=${new Date().getTime()}`;
     }
   }
 
@@ -178,9 +178,16 @@ export class MiPerfilPersonalizadoComponent implements OnInit {
         this.guardarPreferencias(finalizarOperacion, () => { exitoAlguno = true; });
     }
 
-    // --- OPERACIÓN 3: Foto de perfil ---
+    // --- OPERACIÓN 3: Foto de perfil (enviada al servidor) ---
     if (hayFoto) {
-        this.fotoService.subirFoto(this.archivoSeleccionado!).subscribe({
+        const formData = new FormData();
+        formData.append('archivo', this.archivoSeleccionado!);
+        
+        this.rest.request<any, any>({
+            method: 'POST',
+            url: '/api/app/foto-perfil/subir',
+            body: formData,
+        }).subscribe({
             next: () => {
                 exitoAlguno = true;
                 this.archivoSeleccionado = null;

--- a/angular/src/app/mi-perfil-personalizado/mi-perfil-personalizado.component.ts
+++ b/angular/src/app/mi-perfil-personalizado/mi-perfil-personalizado.component.ts
@@ -7,6 +7,7 @@ import { CommonModule } from '@angular/common';
 import { ConfirmationService, Confirmation } from '@abp/ng.theme.shared';
 import { AuthService } from '@abp/ng.core';
 import { CuentaService } from '../proxy/cuentas/cuenta.service';
+import { PreferenciasNotificacionService, FrecuenciaNotificacion } from '../proxy/notificaciones';
 
 @Component({
   selector: 'app-mi-perfil-personalizado',
@@ -22,7 +23,8 @@ export class MiPerfilPersonalizadoComponent implements OnInit {
   private configState = inject(ConfigStateService);
   private confirmation = inject(ConfirmationService); 
   private authService = inject(AuthService);          
-  private cuentaService = inject(CuentaService);      
+  private cuentaService = inject(CuentaService);
+  private preferenciasService = inject(PreferenciasNotificacionService);      
 
   form: FormGroup;
   estaCargando = signal(false);
@@ -57,6 +59,24 @@ export class MiPerfilPersonalizadoComponent implements OnInit {
 
     // 3. Cargamos los datos del formulario
     this.cargarDatos();
+
+    // 4. Cargamos las preferencias de notificación
+    this.cargarPreferencias();
+  }
+
+  cargarPreferencias() {
+    this.preferenciasService.getMiPreferencia().subscribe({
+      next: (prefs) => {
+        this.form.patchValue({
+          notifyScreen: prefs.enPantalla,
+          notifyEmail: prefs.porEmail,
+          notifyFrequency: prefs.frecuencia === FrecuenciaNotificacion.Inmediata ? 'immediate' : 'weekly'
+        });
+      },
+      error: () => {
+        // Si falla, dejamos los valores por defecto del form
+      }
+    });
   }
 
   cargarDatos() {
@@ -133,6 +153,9 @@ export class MiPerfilPersonalizadoComponent implements OnInit {
       body: datosParaApi // <--- Enviamos el objeto filtrado, no el form completo
     }).subscribe({
       next: () => {
+        // Guardamos las preferencias de notificación
+        this.guardarPreferencias();
+
         // Si además había foto seleccionada, la subimos ahora
         if (this.archivoSeleccionado) {
             this.subirSoloFoto();
@@ -146,6 +169,25 @@ export class MiPerfilPersonalizadoComponent implements OnInit {
       error: (err) => {
         this.toaster.error('Error al guardar los datos personales.', 'Error');
         this.estaCargando.set(false);
+      }
+    });
+  }
+
+  guardarPreferencias() {
+    const formValues = this.form.getRawValue();
+    
+    this.preferenciasService.updateMiPreferencia({
+      enPantalla: formValues.notifyScreen,
+      porEmail: formValues.notifyEmail,
+      frecuencia: formValues.notifyFrequency === 'immediate' 
+        ? FrecuenciaNotificacion.Inmediata 
+        : FrecuenciaNotificacion.ResumenSemanal
+    }).subscribe({
+      next: () => {
+        // Preferencias guardadas silenciosamente
+      },
+      error: () => {
+        this.toaster.warn('No se pudieron guardar las preferencias de notificación.', 'Atención');
       }
     });
   }

--- a/angular/src/app/mi-perfil-personalizado/mi-perfil-personalizado.component.ts
+++ b/angular/src/app/mi-perfil-personalizado/mi-perfil-personalizado.component.ts
@@ -113,67 +113,89 @@ export class MiPerfilPersonalizadoComponent implements OnInit {
   }
 
   guardar() {
-    // Validamos: Si el formulario es inválido y se intentó cambiar texto, paramos.
-    if (this.form.invalid && !this.form.pristine) return;
+    if (this.form.invalid) return;
 
     this.estaCargando.set(true);
 
-    // ESCENARIO 1: Solo se seleccionó foto nueva (Texto sin cambios)
-    if (this.form.pristine && this.archivoSeleccionado) {
-        this.subirSoloFoto();
+    // Detectamos QUÉ cambió para ejecutar solo las llamadas necesarias
+    const perfilCambio = ['email', 'name', 'surname', 'phoneNumber']
+        .some(f => this.form.get(f)?.dirty);
+    const prefsCambio = ['notifyScreen', 'notifyEmail', 'notifyFrequency']
+        .some(f => this.form.get(f)?.dirty);
+    const hayFoto = !!this.archivoSeleccionado;
+
+    // Contamos operaciones pendientes para saber cuándo terminó todo
+    let operacionesPendientes = 0;
+    if (perfilCambio) operacionesPendientes++;
+    if (prefsCambio) operacionesPendientes++;
+    if (hayFoto) operacionesPendientes++;
+
+    // Si nada cambió (no debería pasar, pero por seguridad)
+    if (operacionesPendientes === 0) {
+        this.estaCargando.set(false);
         return;
     }
 
-    // ESCENARIO 2: Se cambió texto (y quizás también foto)
-    
-    // --- CAMBIO IMPORTANTE AQUÍ ---
-    // Obtenemos todos los valores del formulario
-    const formValues = this.form.getRawValue();
+    let exitoAlguno = false;
 
-    // Filtramos SOLO los datos que el Backend actual entiende (ProfileUpdateDto)
-    // Dejamos fuera 'notifyScreen', 'notifyEmail', etc. para que no rompa la API.
-    const datosParaApi = {
-        userName: formValues.userName,
-        email: formValues.email,
-        name: formValues.name,
-        surname: formValues.surname,
-        phoneNumber: formValues.phoneNumber
-    };
-    
-    // Aquí podrías guardar las preferencias en LocalStorage temporalmente si quisieras
-    // console.log('Preferencias seleccionadas:', { 
-    //    screen: formValues.notifyScreen, 
-    //    email: formValues.notifyEmail,
-    //    freq: formValues.notifyFrequency 
-    // });
-
-    this.rest.request<any, any>({
-      method: 'PUT',
-      url: '/api/account/my-profile',
-      body: datosParaApi // <--- Enviamos el objeto filtrado, no el form completo
-    }).subscribe({
-      next: () => {
-        // Guardamos las preferencias de notificación
-        this.guardarPreferencias();
-
-        // Si además había foto seleccionada, la subimos ahora
-        if (this.archivoSeleccionado) {
-            this.subirSoloFoto();
-        } else {
-            // Solo texto cambiado
-            this.toaster.success('Perfil actualizado correctamente.', 'Éxito');
-            this.form.markAsPristine(); // Reseteamos estado del form
+    const finalizarOperacion = () => {
+        operacionesPendientes--;
+        if (operacionesPendientes <= 0) {
+            if (exitoAlguno) {
+                this.toaster.success('Cambios guardados correctamente.', 'Éxito');
+            }
+            this.form.markAsPristine();
             this.estaCargando.set(false);
         }
-      },
-      error: (err) => {
-        this.toaster.error('Error al guardar los datos personales.', 'Error');
-        this.estaCargando.set(false);
-      }
-    });
+    };
+
+    // --- OPERACIÓN 1: Datos del perfil ---
+    if (perfilCambio) {
+        const formValues = this.form.getRawValue();
+        const datosParaApi = {
+            userName: formValues.userName,
+            email: formValues.email,
+            name: formValues.name,
+            surname: formValues.surname,
+            phoneNumber: formValues.phoneNumber
+        };
+
+        this.rest.request<any, any>({
+            method: 'PUT',
+            url: '/api/account/my-profile',
+            body: datosParaApi
+        }).subscribe({
+            next: () => { exitoAlguno = true; finalizarOperacion(); },
+            error: () => {
+                this.toaster.error('Error al guardar los datos personales.', 'Error');
+                finalizarOperacion();
+            }
+        });
+    }
+
+    // --- OPERACIÓN 2: Preferencias de notificación (INDEPENDIENTE del perfil) ---
+    if (prefsCambio) {
+        this.guardarPreferencias(finalizarOperacion, () => { exitoAlguno = true; });
+    }
+
+    // --- OPERACIÓN 3: Foto de perfil ---
+    if (hayFoto) {
+        this.fotoService.subirFoto(this.archivoSeleccionado!).subscribe({
+            next: () => {
+                exitoAlguno = true;
+                this.archivoSeleccionado = null;
+                this.actualizarUrlImagen();
+                finalizarOperacion();
+            },
+            error: () => {
+                this.toaster.warn('Hubo un error al subir la imagen.', 'Atención');
+                finalizarOperacion();
+            }
+        });
+    }
   }
 
-  guardarPreferencias() {
+  guardarPreferencias(onComplete?: () => void, onSuccess?: () => void) {
     const formValues = this.form.getRawValue();
     
     this.preferenciasService.updateMiPreferencia({
@@ -184,34 +206,16 @@ export class MiPerfilPersonalizadoComponent implements OnInit {
         : FrecuenciaNotificacion.ResumenSemanal
     }).subscribe({
       next: () => {
-        // Preferencias guardadas silenciosamente
+        onSuccess?.();
+        onComplete?.();
       },
       error: () => {
         this.toaster.warn('No se pudieron guardar las preferencias de notificación.', 'Atención');
+        onComplete?.();
       }
     });
   }
 
-  // Método auxiliar para no repetir la lógica de subida
-  subirSoloFoto() {
-    if (!this.archivoSeleccionado) return;
-
-    this.fotoService.subirFoto(this.archivoSeleccionado).subscribe({
-        next: () => {
-            this.toaster.success('Foto de perfil actualizada.', 'Éxito');
-            this.estaCargando.set(false);
-            
-            this.archivoSeleccionado = null; 
-            this.form.markAsPristine(); 
-            this.actualizarUrlImagen(); 
-        },
-        error: () => {
-            this.toaster.warn('Datos guardados pero hubo error con la imagen.', 'Atención');
-            this.estaCargando.set(false);
-        }
-    });
-  }
-  
   cargarImagenPorDefecto() {
     this.urlImagen = null;
   }

--- a/angular/src/app/proxy/notificaciones/index.ts
+++ b/angular/src/app/proxy/notificaciones/index.ts
@@ -1,2 +1,3 @@
 export * from './models';
 export * from './notificacion.service';
+export * from './preferencias-notificacion.service';

--- a/angular/src/app/proxy/notificaciones/models.ts
+++ b/angular/src/app/proxy/notificaciones/models.ts
@@ -9,3 +9,21 @@ export interface NotificacionDto {
   fecha?: string;
   color?: string;
 }
+
+export enum FrecuenciaNotificacion {
+  Inmediata = 0,
+  ResumenSemanal = 1,
+}
+
+export interface PreferenciasNotificacionDto {
+  id?: string;
+  enPantalla: boolean;
+  porEmail: boolean;
+  frecuencia: FrecuenciaNotificacion;
+}
+
+export interface UpdatePreferenciasDto {
+  enPantalla: boolean;
+  porEmail: boolean;
+  frecuencia: FrecuenciaNotificacion;
+}

--- a/angular/src/app/proxy/notificaciones/preferencias-notificacion.service.ts
+++ b/angular/src/app/proxy/notificaciones/preferencias-notificacion.service.ts
@@ -1,0 +1,27 @@
+import type { PreferenciasNotificacionDto, UpdatePreferenciasDto } from './models';
+import { RestService, Rest } from '@abp/ng.core';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PreferenciasNotificacionService {
+  apiName = 'Default';
+
+  getMiPreferencia = (config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PreferenciasNotificacionDto>({
+      method: 'GET',
+      url: '/api/app/preferencias-notificacion/mi-preferencia',
+    },
+    { apiName: this.apiName, ...config });
+
+  updateMiPreferencia = (input: UpdatePreferenciasDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PreferenciasNotificacionDto>({
+      method: 'PUT',
+      url: '/api/app/preferencias-notificacion/mi-preferencia',
+      body: input,
+    },
+    { apiName: this.apiName, ...config });
+
+  constructor(private restService: RestService) {}
+}

--- a/angular/src/app/services/foto-perfil.service.ts
+++ b/angular/src/app/services/foto-perfil.service.ts
@@ -1,79 +1,31 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FotoPerfilService {
-  private localStorageKey = 'foto-perfil-usuario';
+  private apiUrl = environment.apis.default.url;
 
   /**
-   * Carga un archivo local y lo convierte a base64, lo guarda en localStorage
-   * 
-   * @param archivo Archivo seleccionado por el usuario
-   * @returns Observable que emite cuando se completa la lectura
-   */
-  subirFoto(archivo: File): Observable<string> {
-    return new Observable((observer) => {
-      // Validar que sea una imagen
-      if (!archivo.type.startsWith('image/')) {
-        observer.error(new Error('El archivo debe ser una imagen'));
-        return;
-      }
-
-      // Validar tamaño (máximo 5MB)
-      const maxSize = 5 * 1024 * 1024; // 5MB
-      if (archivo.size > maxSize) {
-        observer.error(new Error('El archivo no debe superar 5MB'));
-        return;
-      }
-
-      // Leer archivo y convertir a base64
-      const reader = new FileReader();
-      reader.onload = (event: any) => {
-        const base64String = event.target.result;
-        // Guardar en localStorage
-        localStorage.setItem(this.localStorageKey, base64String);
-        observer.next(base64String);
-        observer.complete();
-      };
-
-      reader.onerror = () => {
-        observer.error(new Error('Error al leer el archivo'));
-      };
-
-      reader.readAsDataURL(archivo);
-    });
-  }
-
-  /**
-   * Obtiene la foto de perfil desde localStorage o devuelve placeholder
-   * 
-   * @param usuarioId ID del usuario (opcional, no se usa en localStorage)
-   * @returns URL en base64 o placeholder gris
+   * Construye la URL del backend para obtener la foto de perfil de un usuario.
+   *
+   * @param usuarioId ID del usuario cuya foto se quiere mostrar
+   * @returns URL completa al endpoint del backend (con cache-buster)
    */
   obtenerUrlFoto(usuarioId?: string): string {
-    const fotoGuardada = localStorage.getItem(this.localStorageKey);
-    
-    if (fotoGuardada) {
-      return fotoGuardada;
+    if (!usuarioId) {
+      return this.getPlaceholder();
     }
+    // Sin cache-buster: el browser cachéa la imagen normalmente.
+    // El perfil personalizado agrega su propio ?t= al actualizar tras subir.
+    return `${this.apiUrl}/api/app/foto-perfil/obtener/${usuarioId}`;
+  }
 
-    // Placeholder gris si no hay foto
+  /**
+   * Devuelve un SVG placeholder gris cuando no hay foto disponible.
+   */
+  getPlaceholder(): string {
     return 'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Crect fill=%22%23e5e7eb%22 width=%22100%22 height=%22100%22/%3E%3Ctext x=%2250%22 y=%2270%22 font-size=%2250%22 fill=%22%239ca3af%22 text-anchor=%22middle%22%3E👤%3C/text%3E%3C/svg%3E';
-  }
-
-  /**
-   * Elimina la foto guardada en localStorage
-   */
-  eliminarFoto(): void {
-    localStorage.removeItem(this.localStorageKey);
-  }
-
-  /**
-   * Comprueba si hay foto guardada
-   */
-  tieneFoto(): boolean {
-    return !!localStorage.getItem(this.localStorageKey);
   }
 }

--- a/angular/src/app/shared/components/notifications/notifications-dropdown/notifications-dropdown.component.html
+++ b/angular/src/app/shared/components/notifications/notifications-dropdown/notifications-dropdown.component.html
@@ -22,19 +22,30 @@
 
     <div class="max-h-80 overflow-y-auto custom-scrollbar">
 
-      <!-- Banner de frecuencia semanal -->
-      <div *ngIf="esFrecuenciaSemanal" class="mx-3 mt-2 mb-1 px-3 py-2.5 bg-amber-50 border border-amber-200 rounded-lg flex items-start gap-2.5">
-        <i class="fa fa-clock text-amber-500 mt-0.5 text-sm"></i>
-        <div>
-          <p class="text-xs font-semibold text-amber-700 leading-tight">Modo resumen semanal activo</p>
-          <p class="text-[10px] text-amber-600 mt-0.5 leading-snug">Tus nuevas notificaciones llegarán los domingos a las 20:00 hs. Podés cambiarlo desde tu <a routerLink="/mi-perfil" class="underline font-semibold hover:text-amber-800">perfil</a>.</p>
+      <!-- Banner informativo de frecuencia semanal -->
+      <div *ngIf="esFrecuenciaSemanal" class="mx-3 mt-3 mb-2 p-3 bg-blue-50 border-l-4 border-blue-500 rounded-r-lg shadow-sm">
+        <div class="flex items-start gap-3">
+          <div class="flex-shrink-0 w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center mt-0.5">
+            <i class="fa fa-calendar-week text-blue-600 text-sm"></i>
+          </div>
+          <div class="flex-1">
+            <h6 class="text-sm font-bold text-blue-900 leading-tight mb-1">
+              Frecuencia semanal activa
+            </h6>
+            <p class="text-xs text-blue-700 leading-relaxed mb-2">
+              Recibirás un resumen con todas tus notificaciones cada <strong>domingo a las 20:00 hs</strong>.
+            </p>
+            <div class="flex items-center gap-1.5 text-[11px] text-blue-600">
+              <i class="fa fa-info-circle"></i>
+              <span>Para cambiar esta configuración, ingresá a tu perfil</span>
+            </div>
+          </div>
         </div>
       </div>
       
       <div *ngFor="let notif of notificaciones" 
-           (click)="clickNotificacion(notif)" 
-           class="px-4 py-3 border-b border-gray-100 hover:bg-orange-50/50 cursor-pointer transition-colors relative group">
-           
+          (click)="clickNotificacion(notif)" 
+          class="px-4 py-3 border-b border-gray-100 hover:bg-orange-50/50 cursor-pointer transition-colors relative group">
         <div *ngIf="!notif.leida" class="absolute left-0 top-0 bottom-0 w-1 bg-blue-600"></div>
 
         <div class="flex items-start gap-3">

--- a/angular/src/app/shared/components/notifications/notifications-dropdown/notifications-dropdown.component.html
+++ b/angular/src/app/shared/components/notifications/notifications-dropdown/notifications-dropdown.component.html
@@ -21,6 +21,15 @@
     </div>
 
     <div class="max-h-80 overflow-y-auto custom-scrollbar">
+
+      <!-- Banner de frecuencia semanal -->
+      <div *ngIf="esFrecuenciaSemanal" class="mx-3 mt-2 mb-1 px-3 py-2.5 bg-amber-50 border border-amber-200 rounded-lg flex items-start gap-2.5">
+        <i class="fa fa-clock text-amber-500 mt-0.5 text-sm"></i>
+        <div>
+          <p class="text-xs font-semibold text-amber-700 leading-tight">Modo resumen semanal activo</p>
+          <p class="text-[10px] text-amber-600 mt-0.5 leading-snug">Tus nuevas notificaciones llegarán los domingos a las 20:00 hs. Podés cambiarlo desde tu <a routerLink="/mi-perfil" class="underline font-semibold hover:text-amber-800">perfil</a>.</p>
+        </div>
+      </div>
       
       <div *ngFor="let notif of notificaciones" 
            (click)="clickNotificacion(notif)" 

--- a/angular/src/app/shared/components/notifications/notifications-dropdown/notifications-dropdown.component.ts
+++ b/angular/src/app/shared/components/notifications/notifications-dropdown/notifications-dropdown.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { NotificacionService } from '../../../../proxy/notificaciones/notificacion.service';
-import { NotificacionDto } from '../../../../proxy/notificaciones/models';
+import { PreferenciasNotificacionService } from '../../../../proxy/notificaciones/preferencias-notificacion.service';
+import { NotificacionDto, FrecuenciaNotificacion } from '../../../../proxy/notificaciones/models';
 
 @Component({
   selector: 'app-notifications-dropdown',
@@ -13,17 +14,20 @@ export class NotificationsDropdownComponent implements OnInit, OnDestroy {
   unreadCount = 0;
   notificaciones: NotificacionDto[] = []; 
   pollingInterval: any;
+  esFrecuenciaSemanal = false;
   
   // Variable para el temporizador del mouse
   closeTimer: any;
 
   constructor(
     private notificacionService: NotificacionService,
+    private preferenciasService: PreferenciasNotificacionService,
     private router: Router
   ) {}
 
   ngOnInit(): void {
     this.cargarDatos();
+    this.cargarPreferencias();
     this.pollingInterval = setInterval(() => {
       this.cargarDatos();
     }, 60000);
@@ -40,6 +44,12 @@ export class NotificationsDropdownComponent implements OnInit, OnDestroy {
     });
     this.notificacionService.getMisNotificaciones().subscribe(list => {
       this.notificaciones = list;
+    });
+  }
+
+  cargarPreferencias() {
+    this.preferenciasService.getMiPreferencia().subscribe(prefs => {
+      this.esFrecuenciaSemanal = prefs.frecuencia === FrecuenciaNotificacion.ResumenSemanal;
     });
   }
 

--- a/angular/src/app/shared/components/notifications/notifications.module.ts
+++ b/angular/src/app/shared/components/notifications/notifications.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CoreModule } from '@abp/ng.core';
 import { ThemeSharedModule } from '@abp/ng.theme.shared';
+import { RouterModule } from '@angular/router';
 
 // Importamos tus componentes
 import { NotificationsDropdownComponent } from './notifications-dropdown/notifications-dropdown.component';
@@ -15,7 +16,8 @@ import { CustomNavItemsComponent } from './custom-nav-items/custom-nav-items.com
   imports: [
     CommonModule,
     CoreModule,
-    ThemeSharedModule // Esto debería traer lo básico
+    ThemeSharedModule,
+    RouterModule
   ],
   exports: [
     CustomNavItemsComponent,

--- a/src/AmmenTravel.Application.Contracts/Notificaciones/IPreferenciasNotificacionAppService.cs
+++ b/src/AmmenTravel.Application.Contracts/Notificaciones/IPreferenciasNotificacionAppService.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using Volo.Abp.Application.Services;
+
+namespace AmmenTravel.Notificaciones
+{
+    public interface IPreferenciasNotificacionAppService : IApplicationService
+    {
+        Task<PreferenciasNotificacionDto> GetMiPreferenciaAsync();
+        Task<PreferenciasNotificacionDto> UpdateMiPreferenciaAsync(UpdatePreferenciasDto input);
+    }
+}

--- a/src/AmmenTravel.Application.Contracts/Notificaciones/PreferenciasNotificacionDto.cs
+++ b/src/AmmenTravel.Application.Contracts/Notificaciones/PreferenciasNotificacionDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace AmmenTravel.Notificaciones
+{
+    public class PreferenciasNotificacionDto
+    {
+        public Guid? Id { get; set; }
+        public bool EnPantalla { get; set; }
+        public bool PorEmail { get; set; }
+        public FrecuenciaNotificacion Frecuencia { get; set; }
+    }
+}

--- a/src/AmmenTravel.Application.Contracts/Notificaciones/UpdatePreferenciasDto.cs
+++ b/src/AmmenTravel.Application.Contracts/Notificaciones/UpdatePreferenciasDto.cs
@@ -1,0 +1,9 @@
+namespace AmmenTravel.Notificaciones
+{
+    public class UpdatePreferenciasDto
+    {
+        public bool EnPantalla { get; set; }
+        public bool PorEmail { get; set; }
+        public FrecuenciaNotificacion Frecuencia { get; set; }
+    }
+}

--- a/src/AmmenTravel.Application/AmmenTravelApplicationModule.cs
+++ b/src/AmmenTravel.Application/AmmenTravelApplicationModule.cs
@@ -49,6 +49,7 @@ public class AmmenTravelApplicationModule : AbpModule
     public override async Task OnApplicationInitializationAsync(ApplicationInitializationContext context)
     { 
         await context.AddBackgroundWorkerAsync<NotificarEventosFavoritosWorker>();
+        await context.AddBackgroundWorkerAsync<WorkerResumenSemanalEmails>();
     }
 
 }

--- a/src/AmmenTravel.Application/EventosExternosAppService.cs
+++ b/src/AmmenTravel.Application/EventosExternosAppService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Volo.Abp.Application.Services;
 
@@ -19,6 +20,7 @@ namespace AmmenTravel.ExternalService
             _configuration = configuration;
         }
 
+        [AllowAnonymous]
         public async Task<List<EventoTicketmasterDto>> ObtenerEventosPorUbicacionAsync(string latitud, string longitud)
         {
             var baseUrl = _configuration["Ticketmaster:BaseUrl"];

--- a/src/AmmenTravel.Application/EventosExternosAppService.cs
+++ b/src/AmmenTravel.Application/EventosExternosAppService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Volo.Abp.Application.Services;
 
@@ -20,7 +19,6 @@ namespace AmmenTravel.ExternalService
             _configuration = configuration;
         }
 
-        [AllowAnonymous]
         public async Task<List<EventoTicketmasterDto>> ObtenerEventosPorUbicacionAsync(string latitud, string longitud)
         {
             var baseUrl = _configuration["Ticketmaster:BaseUrl"];

--- a/src/AmmenTravel.Application/Notificaciones/EmailTemplateHelper.cs
+++ b/src/AmmenTravel.Application/Notificaciones/EmailTemplateHelper.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Net;
+using System.Text;
+
+namespace AmmenTravel.Notificaciones
+{
+    /// <summary>
+    /// Helper estático para generar plantillas HTML de emails de notificación.
+    /// Centraliza el diseño para mantener consistencia visual en todos los emails.
+    /// </summary>
+    public static class EmailTemplateHelper
+    {
+        /// <summary>
+        /// Genera un email HTML para una notificación individual (modo inmediato).
+        /// </summary>
+        public static string GenerarEmailNotificacion(string titulo, string mensaje, string? linkAccion = null, string textoBoton = "Ver en AmmenTravel")
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine("<!DOCTYPE html>");
+            sb.AppendLine("<html lang='es'>");
+            sb.AppendLine("<head>");
+            sb.AppendLine("<meta charset='utf-8'>");
+            sb.AppendLine("<meta name='viewport' content='width=device-width, initial-scale=1.0'>");
+            sb.AppendLine("<style>");
+            sb.AppendLine("body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f5f5f5; margin: 0; padding: 20px; }");
+            sb.AppendLine(".container { max-width: 600px; margin: 0 auto; background-color: white; border-radius: 10px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); padding: 30px; }");
+            sb.AppendLine(".header { text-align: center; border-bottom: 2px solid #4CAF50; padding-bottom: 20px; margin-bottom: 20px; }");
+            sb.AppendLine(".header h1 { color: #333; margin: 0; font-size: 24px; }");
+            sb.AppendLine(".content { padding: 10px 0; }");
+            sb.AppendLine(".content h2 { color: #333; font-size: 20px; margin-bottom: 10px; }");
+            sb.AppendLine(".content p { color: #555; font-size: 16px; line-height: 1.6; }");
+            sb.AppendLine(".cta-button { display: inline-block; background-color: #4CAF50; color: white !important; padding: 12px 30px; text-decoration: none; border-radius: 5px; margin-top: 20px; font-size: 16px; }");
+            sb.AppendLine(".footer { text-align: center; margin-top: 30px; padding-top: 20px; border-top: 1px solid #eee; color: #999; font-size: 12px; }");
+            sb.AppendLine("</style>");
+            sb.AppendLine("</head>");
+            sb.AppendLine("<body>");
+            sb.AppendLine("<div class='container'>");
+
+            // Header
+            sb.AppendLine("<div class='header'>");
+            sb.AppendLine("<h1>🌍 AmmenTravel</h1>");
+            sb.AppendLine("</div>");
+
+            // Content
+            sb.AppendLine("<div class='content'>");
+            sb.AppendLine($"<h2>{Escape(titulo)}</h2>");
+            sb.AppendLine($"<p>{Escape(mensaje)}</p>");
+            sb.AppendLine("</div>");
+
+            // CTA Button
+            if (!string.IsNullOrEmpty(linkAccion))
+            {
+                var urlCompleta = linkAccion.StartsWith("http") ? linkAccion : $"https://ammentravel.com{linkAccion}";
+                sb.AppendLine("<div style='text-align: center;'>");
+                sb.AppendLine($"<a href='{Escape(urlCompleta)}' class='cta-button'>{Escape(textoBoton)}</a>");
+                sb.AppendLine("</div>");
+            }
+
+            // Footer
+            sb.AppendLine("<div class='footer'>");
+            sb.AppendLine("<p>Recibiste este email porque tenés activadas las notificaciones por email en tu perfil de AmmenTravel.</p>");
+            sb.AppendLine("<p>© 2026 AmmenTravel - Tu compañero de viajes</p>");
+            sb.AppendLine("</div>");
+
+            sb.AppendLine("</div>");
+            sb.AppendLine("</body>");
+            sb.AppendLine("</html>");
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Genera un email HTML para notificaciones de logros/gamificación.
+        /// </summary>
+        public static string GenerarEmailLogro(string titulo, string mensaje)
+        {
+            return GenerarEmailNotificacion(titulo, mensaje, "/mi-perfil/mis-calificaciones", "Ver mi perfil");
+        }
+
+        /// <summary>
+        /// Genera un email HTML para notificaciones de eventos en favoritos.
+        /// </summary>
+        public static string GenerarEmailEventoFavorito(string titulo, string mensaje)
+        {
+            return GenerarEmailNotificacion(titulo, mensaje, "/favoritos", "Ver mis favoritos");
+        }
+
+        /// <summary>
+        /// Genera un email HTML para notificaciones de opiniones en destinos favoritos.
+        /// </summary>
+        public static string GenerarEmailOpinionFavorito(string titulo, string mensaje, Guid? destinoId = null)
+        {
+            var link = destinoId.HasValue ? $"/destinos/{destinoId.Value}" : "/favoritos";
+            return GenerarEmailNotificacion(titulo, mensaje, link, "Ver destino");
+        }
+
+        /// <summary>
+        /// Genera un email HTML para notificaciones de reactivación.
+        /// </summary>
+        public static string GenerarEmailReactivacion(string titulo, string mensaje)
+        {
+            return GenerarEmailNotificacion(titulo, mensaje, "/mi-perfil/mis-calificaciones", "Compartir una experiencia");
+        }
+
+        private static string Escape(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+            return WebUtility.HtmlEncode(text);
+        }
+    }
+}

--- a/src/AmmenTravel.Application/Notificaciones/ManejadorEventosFavoritos.cs
+++ b/src/AmmenTravel.Application/Notificaciones/ManejadorEventosFavoritos.cs
@@ -93,14 +93,15 @@ namespace AmmenTravel.Notificaciones
                             await _notificacionRepository.InsertAsync(notificacion);
                         }
 
-                        // Email
+                        // Email (HTML)
                         if (porEmail)
                         {
                             var user = await _userManager.FindByIdAsync(eventData.UserId.ToString());
                             var email = user?.Email;
                             if (!string.IsNullOrEmpty(email))
                             {
-                                await _emailSender.SendAsync(email, titulo, mensaje);
+                                var htmlBody = EmailTemplateHelper.GenerarEmailEventoFavorito(titulo, mensaje);
+                                await _emailSender.SendAsync(email, titulo, htmlBody, isBodyHtml: true);
                             }
                         }
                     }

--- a/src/AmmenTravel.Application/Notificaciones/ManejadorEventosFavoritos.cs
+++ b/src/AmmenTravel.Application/Notificaciones/ManejadorEventosFavoritos.cs
@@ -8,8 +8,10 @@ using AmmenTravel.ListaDeFavoritos;
 using Microsoft.Extensions.Logging;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Emailing;
 using Volo.Abp.EventBus;
 using Volo.Abp.Guids;
+using Volo.Abp.Identity;
 
 namespace AmmenTravel.Notificaciones
 {
@@ -18,6 +20,10 @@ namespace AmmenTravel.Notificaciones
         private readonly IRepository<DestinoTuristico, Guid> _destinoRepository;
         private readonly IEventosExternosAppService _eventosExternosService;
         private readonly IRepository<Notificacion, Guid> _notificacionRepository;
+        private readonly IRepository<PreferenciasNotificacion, Guid> _preferenciasRepo;
+        private readonly IRepository<ColaResumenSemanalEmail, Guid> _colaEmailRepo;
+        private readonly IdentityUserManager _userManager;
+        private readonly IEmailSender _emailSender;
         private readonly IGuidGenerator _guidGenerator;
         private readonly ILogger<ManejadorEventosFavoritos> _logger;
 
@@ -25,12 +31,20 @@ namespace AmmenTravel.Notificaciones
             IRepository<DestinoTuristico, Guid> destinoRepository,
             IEventosExternosAppService eventosExternosService,
             IRepository<Notificacion, Guid> notificacionRepository,
+            IRepository<PreferenciasNotificacion, Guid> preferenciasRepo,
+            IRepository<ColaResumenSemanalEmail, Guid> colaEmailRepo,
+            IdentityUserManager userManager,
+            IEmailSender emailSender,
             IGuidGenerator guidGenerator,
             ILogger<ManejadorEventosFavoritos> logger)
         {
             _destinoRepository = destinoRepository;
             _eventosExternosService = eventosExternosService;
             _notificacionRepository = notificacionRepository;
+            _preferenciasRepo = preferenciasRepo;
+            _colaEmailRepo = colaEmailRepo;
+            _userManager = userManager;
+            _emailSender = emailSender;
             _guidGenerator = guidGenerator;
             _logger = logger;
         }
@@ -49,28 +63,62 @@ namespace AmmenTravel.Notificaciones
                 if (eventos != null && eventos.Any())
                 {
                     int cantidadEventos = eventos.Count;
-                    string mensaje;
+                    string titulo = $"¡Planazo en {destino.Nombre}! 🎟️";
+                    string mensaje = cantidadEventos == 1
+                        ? $"Acabas de guardar {destino.Nombre} y hay un evento próximo esperandote. ¡Revisalo antes de que se agote!"
+                        : $"Acabas de guardar {destino.Nombre} y hay {cantidadEventos} eventos próximos esperando. ¡Sacá tus tickets!";
 
-                    if (cantidadEventos == 1)
+                    // Obtenemos las preferencias del usuario (o valores por defecto)
+                    var preferencias = await _preferenciasRepo.FirstOrDefaultAsync(p => p.UserId == eventData.UserId);
+                    bool enPantalla = preferencias?.EnPantalla ?? true;
+                    bool porEmail = preferencias?.PorEmail ?? true;
+                    FrecuenciaNotificacion frecuencia = preferencias?.Frecuencia ?? FrecuenciaNotificacion.Inmediata;
+
+                    if (frecuencia == FrecuenciaNotificacion.Inmediata)
                     {
-                        mensaje = $"Acabas de guardar {destino.Nombre} y hay un evento próximo espereandote. ¡Revisalo antes de que se agote!";
+                        // === MODO INMEDIATO: todo al instante ===
+
+                        // Campanita
+                        if (enPantalla)
+                        {
+                            var notificacion = new Notificacion(
+                                _guidGenerator.Create(),
+                                eventData.UserId,
+                                titulo,
+                                mensaje,
+                                TipoNotificacion.Social,
+                                "/favoritos", 
+                                "fa-ticket-alt"
+                            );
+                            await _notificacionRepository.InsertAsync(notificacion);
+                        }
+
+                        // Email
+                        if (porEmail)
+                        {
+                            var user = await _userManager.FindByIdAsync(eventData.UserId.ToString());
+                            var email = user?.Email;
+                            if (!string.IsNullOrEmpty(email))
+                            {
+                                await _emailSender.SendAsync(email, titulo, mensaje);
+                            }
+                        }
                     }
                     else
                     {
-                        mensaje = $"Acabas de guardar {destino.Nombre} y hay {cantidadEventos} eventos próximos esperando. ¡Sacá tus tickets!";
+                        // === MODO SEMANAL: todo se encola para el domingo ===
+                        var user = await _userManager.FindByIdAsync(eventData.UserId.ToString());
+                        var email = user?.Email ?? "";
+
+                        var colaEmail = new ColaResumenSemanalEmail(
+                            _guidGenerator.Create(),
+                            eventData.UserId,
+                            email,
+                            titulo,
+                            mensaje
+                        );
+                        await _colaEmailRepo.InsertAsync(colaEmail);
                     }
-
-                    var notificacion = new Notificacion(
-                        _guidGenerator.Create(),
-                        eventData.UserId,
-                        $"¡Planazo en {destino.Nombre}! 🎟️",
-                        mensaje,
-                        TipoNotificacion.Social,
-                        "/favoritos", 
-                        "fa-ticket-alt"
-                    );
-
-                    await _notificacionRepository.InsertAsync(notificacion);
                 }
             }
             catch (Exception ex)

--- a/src/AmmenTravel.Application/Notificaciones/ManejadorEventosOpinion.cs
+++ b/src/AmmenTravel.Application/Notificaciones/ManejadorEventosOpinion.cs
@@ -2,19 +2,22 @@
 using AmmenTravel.ListaFavoritos;
 using AmmenTravel.Opiniones;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Volo.Abp.DependencyInjection;
-using Volo.Abp.Domain.Entities.Events; // Para EntityCreatedEventData
+using Volo.Abp.Domain.Entities.Events;
 using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Emailing;
 using Volo.Abp.EventBus;
 using Volo.Abp.Guids;
+using Volo.Abp.Identity;
 
 namespace AmmenTravel.Notificaciones
 {
     public class ManejadorEventosOpinion :
-        ILocalEventHandler<EntityCreatedEventData<Opinion>>, // Escucha cuando se CREA una opinión
+        ILocalEventHandler<EntityCreatedEventData<Opinion>>,
         ITransientDependency
     {
         private readonly IRepository<Notificacion, Guid> _notificacionRepository;
@@ -22,7 +25,12 @@ namespace AmmenTravel.Notificaciones
         private readonly IRepository<DestinoTuristico, Guid> _destinoRepository;
         private readonly IRepository<LineaListaFavorito, Guid> _favoritosRepository;
         private readonly IRepository<ListaFavorito, Guid> _listaFavoritoRepository;
+        private readonly IRepository<PreferenciasNotificacion, Guid> _preferenciasRepo;
+        private readonly IRepository<ColaResumenSemanalEmail, Guid> _colaEmailRepo;
+        private readonly IdentityUserManager _userManager;
+        private readonly IEmailSender _emailSender;
         private readonly IGuidGenerator _guidGenerator;
+        private readonly ILogger<ManejadorEventosOpinion> _logger;
 
         public ManejadorEventosOpinion(
             IRepository<Notificacion, Guid> notificacionRepository,
@@ -30,14 +38,24 @@ namespace AmmenTravel.Notificaciones
             IRepository<DestinoTuristico, Guid> destinoRepository,
             IRepository<LineaListaFavorito, Guid> favoritosRepository,
             IRepository<ListaFavorito, Guid> listaFavoritoRepository,
-            IGuidGenerator guidGenerator)
+            IRepository<PreferenciasNotificacion, Guid> preferenciasRepo,
+            IRepository<ColaResumenSemanalEmail, Guid> colaEmailRepo,
+            IdentityUserManager userManager,
+            IEmailSender emailSender,
+            IGuidGenerator guidGenerator,
+            ILogger<ManejadorEventosOpinion> logger)
         {
             _notificacionRepository = notificacionRepository;
             _opinionRepository = opinionRepository;
             _destinoRepository = destinoRepository;
             _favoritosRepository = favoritosRepository;
             _listaFavoritoRepository = listaFavoritoRepository;
+            _preferenciasRepo = preferenciasRepo;
+            _colaEmailRepo = colaEmailRepo;
+            _userManager = userManager;
+            _emailSender = emailSender;
             _guidGenerator = guidGenerator;
+            _logger = logger;
         }
 
         public async Task HandleEventAsync(EntityCreatedEventData<Opinion> eventData)
@@ -57,14 +75,14 @@ namespace AmmenTravel.Notificaciones
             // Primer Hito
             if (totalOpinionesUsuario == 1)
             {
-                await CrearNotificacion(userId, "¡Primer Hito Desbloqueado! 🚀",
+                await CrearNotificacionConEmail(userId, "¡Primer Hito Desbloqueado! 🚀",
                     "Has publicado tu primera reseña. Tu pasaporte virtual ha comenzado.",
                     TipoNotificacion.Exito, "fa-passport");
             }
             // Nivel Experto
             else if (totalOpinionesUsuario == 10)
             {
-                await CrearNotificacion(userId, "¡Subiste de Nivel! 🌟",
+                await CrearNotificacionConEmail(userId, "¡Subiste de Nivel! 🌟",
                     "Con 10 reseñas, ahora eres un Viajero Experimentado.",
                     TipoNotificacion.Exito, "fa-star");
             }
@@ -80,7 +98,7 @@ namespace AmmenTravel.Notificaciones
             // Disparo de notificación cuando el usuario tiene 3 destinos distintos
             if (destinosDistintos == 3)
             {
-                await CrearNotificacion(userId, "¡Racha de Viajero! 🔥",
+                await CrearNotificacionConEmail(userId, "¡Racha de Viajero! 🔥",
                    "Estás compartiendo muchas experiencias. ¡Sigue así!",
                    TipoNotificacion.Exito, "fa-fire");
             }
@@ -93,7 +111,7 @@ namespace AmmenTravel.Notificaciones
             if (totalOpinionesDestino == 1)
             {
                 // Si es 1, significa que esta es la primera (o acaba de ser creada y es la única)
-                await CrearNotificacion(userId, "¡Sos un Pionero! 🚩",
+                await CrearNotificacionConEmail(userId, "¡Sos un Pionero! 🚩",
                     $"Abriste el camino. Sos el primero en opinar sobre {destino.Nombre}.",
                     TipoNotificacion.Exito, "fa-flag");
             }
@@ -116,28 +134,77 @@ namespace AmmenTravel.Notificaciones
             {
                 if (ownerId == Guid.Empty || ownerId == userId) continue;
 
-                await CrearNotificacion(ownerId, "¡Novedades en tus favoritos! 🔔",
-                    $"Alguien acaba de opinar sobre {destino.Nombre}. Mira qué dicen.",
-                    TipoNotificacion.Social, "fa-heart", $"/destinos/{destinoId}");
+                var tituloFav = "¡Novedades en tus favoritos! 🔔";
+                var mensajeFav = $"Alguien acaba de opinar sobre {destino.Nombre}. Mira qué dicen.";
+
+                await CrearNotificacionConEmail(ownerId, tituloFav, mensajeFav,
+                    TipoNotificacion.Social, "fa-heart", $"/destinos/{destinoId}", destinoId);
             }
         }
 
-        private async Task CrearNotificacion(Guid userId, string titulo, string mensaje, TipoNotificacion tipo, string icono, string link = null)
+        /// <summary>
+        /// Crea una notificación en pantalla y/o envía email según las preferencias del usuario.
+        /// Respeta la frecuencia: inmediata o resumen semanal.
+        /// </summary>
+        private async Task CrearNotificacionConEmail(
+            Guid userId, string titulo, string mensaje,
+            TipoNotificacion tipo, string icono,
+            string link = null, Guid? destinoId = null)
         {
-            await _notificacionRepository.InsertAsync(
-                new Notificacion(_guidGenerator.Create(), userId, titulo, mensaje, tipo, link, icono)
-            );
-        }
+            try
+            {
+                var preferencias = await _preferenciasRepo.FirstOrDefaultAsync(p => p.UserId == userId);
+                bool enPantalla = preferencias?.EnPantalla ?? true;
+                bool porEmail = preferencias?.PorEmail ?? true;
+                FrecuenciaNotificacion frecuencia = preferencias?.Frecuencia ?? FrecuenciaNotificacion.Inmediata;
 
-        // Helper auxiliar (implementar lógica real con repositorios)
-        private async Task<Guid> ObtenerDueñoLista(Guid listaId)
-        {
-            if (listaId == Guid.Empty) return Guid.Empty;
+                if (frecuencia == FrecuenciaNotificacion.Inmediata)
+                {
+                    // Campanita
+                    if (enPantalla)
+                    {
+                        await _notificacionRepository.InsertAsync(
+                            new Notificacion(_guidGenerator.Create(), userId, titulo, mensaje, tipo, link, icono)
+                        );
+                    }
 
-            // Intentamos obtener la lista; FirstOrDefaultAsync evita excepciones si no existe
-            var lista = await _listaFavoritoRepository.FirstOrDefaultAsync(l => l.Id == listaId);
+                    // Email inmediato
+                    if (porEmail)
+                    {
+                        var user = await _userManager.FindByIdAsync(userId.ToString());
+                        var email = user?.Email;
+                        if (!string.IsNullOrEmpty(email))
+                        {
+                            string htmlBody;
+                            if (tipo == TipoNotificacion.Social && destinoId.HasValue)
+                                htmlBody = EmailTemplateHelper.GenerarEmailOpinionFavorito(titulo, mensaje, destinoId);
+                            else
+                                htmlBody = EmailTemplateHelper.GenerarEmailLogro(titulo, mensaje);
 
-            return lista?.UserId ?? Guid.Empty;
+                            await _emailSender.SendAsync(email, titulo, htmlBody, isBodyHtml: true);
+                        }
+                    }
+                }
+                else
+                {
+                    // Modo semanal: encolar para el resumen del domingo
+                    var user = await _userManager.FindByIdAsync(userId.ToString());
+                    var email = user?.Email ?? "";
+
+                    var colaEmail = new ColaResumenSemanalEmail(
+                        _guidGenerator.Create(),
+                        userId,
+                        email,
+                        titulo,
+                        mensaje
+                    );
+                    await _colaEmailRepo.InsertAsync(colaEmail);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error al enviar notificación/email para usuario {UserId}", userId);
+            }
         }
     }
 }

--- a/src/AmmenTravel.Application/Notificaciones/PreferenciasNotificacionAppService.cs
+++ b/src/AmmenTravel.Application/Notificaciones/PreferenciasNotificacionAppService.cs
@@ -138,10 +138,11 @@ namespace AmmenTravel.Notificaciones
                     await _notificacionRepo.InsertAsync(notificacion);
                 }
 
-                // Email
+                // Email (HTML)
                 if (porEmail && !string.IsNullOrEmpty(item.EmailDestino))
                 {
-                    await _emailSender.SendAsync(item.EmailDestino, item.Titulo, item.Mensaje);
+                    var htmlBody = EmailTemplateHelper.GenerarEmailNotificacion(item.Titulo, item.Mensaje, "/favoritos", "Ver en AmmenTravel");
+                    await _emailSender.SendAsync(item.EmailDestino, item.Titulo, htmlBody, isBodyHtml: true);
                 }
 
                 // Marcar como procesado

--- a/src/AmmenTravel.Application/Notificaciones/PreferenciasNotificacionAppService.cs
+++ b/src/AmmenTravel.Application/Notificaciones/PreferenciasNotificacionAppService.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Emailing;
+using Volo.Abp.Guids;
+
+namespace AmmenTravel.Notificaciones
+{
+    [Authorize]
+    public class PreferenciasNotificacionAppService : AmmenTravelAppService, IPreferenciasNotificacionAppService
+    {
+        private readonly IRepository<PreferenciasNotificacion, Guid> _preferenciasRepository;
+        private readonly IRepository<ColaResumenSemanalEmail, Guid> _colaEmailRepo;
+        private readonly IRepository<Notificacion, Guid> _notificacionRepo;
+        private readonly IEmailSender _emailSender;
+        private readonly IGuidGenerator _guidGenerator;
+
+        public PreferenciasNotificacionAppService(
+            IRepository<PreferenciasNotificacion, Guid> preferenciasRepository,
+            IRepository<ColaResumenSemanalEmail, Guid> colaEmailRepo,
+            IRepository<Notificacion, Guid> notificacionRepo,
+            IEmailSender emailSender,
+            IGuidGenerator guidGenerator)
+        {
+            _preferenciasRepository = preferenciasRepository;
+            _colaEmailRepo = colaEmailRepo;
+            _notificacionRepo = notificacionRepo;
+            _emailSender = emailSender;
+            _guidGenerator = guidGenerator;
+        }
+
+        public async Task<PreferenciasNotificacionDto> GetMiPreferenciaAsync()
+        {
+            var userId = CurrentUser.Id!.Value;
+
+            var preferencia = await _preferenciasRepository
+                .FirstOrDefaultAsync(x => x.UserId == userId);
+
+            if (preferencia == null)
+            {
+                // Valores por defecto si no existe registro
+                return new PreferenciasNotificacionDto
+                {
+                    Id = null,
+                    EnPantalla = true,
+                    PorEmail = true,
+                    Frecuencia = FrecuenciaNotificacion.Inmediata
+                };
+            }
+
+            return new PreferenciasNotificacionDto
+            {
+                Id = preferencia.Id,
+                EnPantalla = preferencia.EnPantalla,
+                PorEmail = preferencia.PorEmail,
+                Frecuencia = preferencia.Frecuencia
+            };
+        }
+
+        public async Task<PreferenciasNotificacionDto> UpdateMiPreferenciaAsync(UpdatePreferenciasDto input)
+        {
+            var userId = CurrentUser.Id!.Value;
+
+            var preferencia = await _preferenciasRepository
+                .FirstOrDefaultAsync(x => x.UserId == userId);
+
+            // Detectamos si está cambiando de Semanal → Inmediata
+            var frecuenciaAnterior = preferencia?.Frecuencia ?? FrecuenciaNotificacion.Inmediata;
+            bool cambioAInmediata = frecuenciaAnterior == FrecuenciaNotificacion.ResumenSemanal
+                                && input.Frecuencia == FrecuenciaNotificacion.Inmediata;
+
+            if (preferencia == null)
+            {
+                // Crear nuevo registro (INSERT)
+                preferencia = new PreferenciasNotificacion(
+                    _guidGenerator.Create(),
+                    userId,
+                    input.EnPantalla,
+                    input.PorEmail,
+                    input.Frecuencia
+                );
+
+                await _preferenciasRepository.InsertAsync(preferencia);
+            }
+            else
+            {
+                // Actualizar existente (UPDATE)
+                preferencia.EnPantalla = input.EnPantalla;
+                preferencia.PorEmail = input.PorEmail;
+                preferencia.Frecuencia = input.Frecuencia;
+
+                await _preferenciasRepository.UpdateAsync(preferencia);
+            }
+
+            // Si cambió de Semanal → Inmediata, despachar toda la cola pendiente
+            if (cambioAInmediata)
+            {
+                await DespacharColaPendienteAsync(userId, input.EnPantalla, input.PorEmail);
+            }
+
+            return new PreferenciasNotificacionDto
+            {
+                Id = preferencia.Id,
+                EnPantalla = preferencia.EnPantalla,
+                PorEmail = preferencia.PorEmail,
+                Frecuencia = preferencia.Frecuencia
+            };
+        }
+
+        /// <summary>
+        /// Despacha inmediatamente todas las notificaciones encoladas del usuario.
+        /// Se ejecuta cuando cambia de ResumenSemanal → Inmediata.
+        /// </summary>
+        private async Task DespacharColaPendienteAsync(Guid userId, bool enPantalla, bool porEmail)
+        {
+            var pendientes = await _colaEmailRepo.GetListAsync(
+                e => e.UserId == userId && !e.Procesado
+            );
+
+            if (!pendientes.Any()) return;
+
+            foreach (var item in pendientes)
+            {
+                // Campanita
+                if (enPantalla)
+                {
+                    var notificacion = new Notificacion(
+                        _guidGenerator.Create(),
+                        userId,
+                        item.Titulo,
+                        item.Mensaje,
+                        TipoNotificacion.Social,
+                        "/favoritos",
+                        "fa-ticket-alt"
+                    );
+                    await _notificacionRepo.InsertAsync(notificacion);
+                }
+
+                // Email
+                if (porEmail && !string.IsNullOrEmpty(item.EmailDestino))
+                {
+                    await _emailSender.SendAsync(item.EmailDestino, item.Titulo, item.Mensaje);
+                }
+
+                // Marcar como procesado
+                item.Procesado = true;
+            }
+
+            await _colaEmailRepo.UpdateManyAsync(pendientes);
+        }
+    }
+}

--- a/src/AmmenTravel.Application/Notificaciones/ReactivacionUsuarioJob.cs
+++ b/src/AmmenTravel.Application/Notificaciones/ReactivacionUsuarioJob.cs
@@ -6,7 +6,8 @@ using Microsoft.Extensions.Logging;
 using Volo.Abp.BackgroundJobs;
 using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
-using Volo.Abp.Identity; // Para usuarios
+using Volo.Abp.Identity;
+using Volo.Abp.Emailing;
 using Volo.Abp.Guids;
 using AmmenTravel.Opiniones;
 
@@ -17,6 +18,10 @@ namespace AmmenTravel.Notificaciones
         private readonly IRepository<IdentityUser, Guid> _userRepository;
         private readonly IRepository<Opinion, Guid> _opinionRepository;
         private readonly IRepository<Notificacion, Guid> _notificacionRepository;
+        private readonly IRepository<PreferenciasNotificacion, Guid> _preferenciasRepo;
+        private readonly IRepository<ColaResumenSemanalEmail, Guid> _colaEmailRepo;
+        private readonly IdentityUserManager _userManager;
+        private readonly IEmailSender _emailSender;
         private readonly IGuidGenerator _guidGenerator;
         private readonly ILogger<ReactivacionUsuarioJob> _logger;
 
@@ -24,12 +29,20 @@ namespace AmmenTravel.Notificaciones
             IRepository<IdentityUser, Guid> userRepository,
             IRepository<Opinion, Guid> opinionRepository,
             IRepository<Notificacion, Guid> notificacionRepository,
+            IRepository<PreferenciasNotificacion, Guid> preferenciasRepo,
+            IRepository<ColaResumenSemanalEmail, Guid> colaEmailRepo,
+            IdentityUserManager userManager,
+            IEmailSender emailSender,
             IGuidGenerator guidGenerator,
             ILogger<ReactivacionUsuarioJob> logger)
         {
             _userRepository = userRepository;
             _opinionRepository = opinionRepository;
             _notificacionRepository = notificacionRepository;
+            _preferenciasRepo = preferenciasRepo;
+            _colaEmailRepo = colaEmailRepo;
+            _userManager = userManager;
+            _emailSender = emailSender;
             _guidGenerator = guidGenerator;
             _logger = logger;
         }
@@ -96,17 +109,58 @@ namespace AmmenTravel.Notificaciones
                         {
                             var titulo = "Te extrañamos en AmmenTravel";
                             var mensaje = "Hace tiempo que no compartes una reseña. ¿Querés contar tu última experiencia?";
-                            var notificacion = new Notificacion(
-                                _guidGenerator.Create(),
-                                userId,
-                                titulo,
-                                mensaje,
-                                TipoNotificacion.Recordatorio,
-                                linkReferencia: "/mi-perfil/mis-calificaciones",
-                                icono: "fa-clock"
-                            );
 
-                            await _notificacionRepository.InsertAsync(notificacion, autoSave: true);
+                            // Obtener preferencias del usuario
+                            var preferencias = await _preferenciasRepo.FirstOrDefaultAsync(p => p.UserId == userId);
+                            bool enPantalla = preferencias?.EnPantalla ?? true;
+                            bool porEmail = preferencias?.PorEmail ?? true;
+                            FrecuenciaNotificacion frecuencia = preferencias?.Frecuencia ?? FrecuenciaNotificacion.Inmediata;
+
+                            if (frecuencia == FrecuenciaNotificacion.Inmediata)
+                            {
+                                // Campanita
+                                if (enPantalla)
+                                {
+                                    var notificacion = new Notificacion(
+                                        _guidGenerator.Create(),
+                                        userId,
+                                        titulo,
+                                        mensaje,
+                                        TipoNotificacion.Recordatorio,
+                                        linkReferencia: "/mi-perfil/mis-calificaciones",
+                                        icono: "fa-clock"
+                                    );
+                                    await _notificacionRepository.InsertAsync(notificacion, autoSave: true);
+                                }
+
+                                // Email inmediato (HTML)
+                                if (porEmail)
+                                {
+                                    var user = await _userManager.FindByIdAsync(userId.ToString());
+                                    var email = user?.Email;
+                                    if (!string.IsNullOrEmpty(email))
+                                    {
+                                        var htmlBody = EmailTemplateHelper.GenerarEmailReactivacion(titulo, mensaje);
+                                        await _emailSender.SendAsync(email, titulo, htmlBody, isBodyHtml: true);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                // Modo semanal: encolar
+                                var user = await _userManager.FindByIdAsync(userId.ToString());
+                                var email = user?.Email ?? "";
+
+                                var colaEmail = new ColaResumenSemanalEmail(
+                                    _guidGenerator.Create(),
+                                    userId,
+                                    email,
+                                    titulo,
+                                    mensaje
+                                );
+                                await _colaEmailRepo.InsertAsync(colaEmail, autoSave: true);
+                            }
+
                             createdCount++;
                         }
                         catch (Exception ex)

--- a/src/AmmenTravel.Application/Workers/NotificadorEventosService.cs
+++ b/src/AmmenTravel.Application/Workers/NotificadorEventosService.cs
@@ -148,14 +148,15 @@ namespace AmmenTravel.BackgroundWorkers
                                         await _notificacionRepository.InsertAsync(notificacion);
                                     }
 
-                                    // Email
+                                    // Email (HTML)
                                     if (porEmail)
                                     {
                                         var user = await _userManager.FindByIdAsync(userId.ToString());
                                         var email = user?.Email;
                                         if (!string.IsNullOrEmpty(email))
                                         {
-                                            await _emailSender.SendAsync(email, titulo, mensaje);
+                                            var htmlBody = EmailTemplateHelper.GenerarEmailEventoFavorito(titulo, mensaje);
+                                            await _emailSender.SendAsync(email, titulo, htmlBody, isBodyHtml: true);
                                         }
                                     }
                                 }

--- a/src/AmmenTravel.Application/Workers/NotificadorEventosService.cs
+++ b/src/AmmenTravel.Application/Workers/NotificadorEventosService.cs
@@ -9,6 +9,8 @@ using Volo.Abp.DependencyInjection;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Uow;
 using Volo.Abp.Guids;
+using Volo.Abp.Emailing;
+using Volo.Abp.Identity;
 using AmmenTravel.ExternalService;
 using AmmenTravel.ListaFavoritos;
 using AmmenTravel.Notificaciones;
@@ -24,7 +26,11 @@ namespace AmmenTravel.BackgroundWorkers
         private readonly IRepository<DestinoTuristico, Guid> _destinoRepository;
         private readonly IEventosExternosAppService _eventosExternosService;
         private readonly IRepository<Notificacion, Guid> _notificacionRepository;
-        private readonly IRepository<HistorialNotificacionEvento, Guid> _historialRepo; // <-- Repo de la memoria de notificaciones
+        private readonly IRepository<HistorialNotificacionEvento, Guid> _historialRepo;
+        private readonly IRepository<PreferenciasNotificacion, Guid> _preferenciasRepo;
+        private readonly IRepository<ColaResumenSemanalEmail, Guid> _colaEmailRepo;
+        private readonly IdentityUserManager _userManager;
+        private readonly IEmailSender _emailSender;
         private readonly IGuidGenerator _guidGenerator;
         private readonly ILogger<NotificadorEventosService> _logger;
 
@@ -35,6 +41,10 @@ namespace AmmenTravel.BackgroundWorkers
             IEventosExternosAppService eventosExternosService,
             IRepository<Notificacion, Guid> notificacionRepository,
             IRepository<HistorialNotificacionEvento, Guid> historialRepo,
+            IRepository<PreferenciasNotificacion, Guid> preferenciasRepo,
+            IRepository<ColaResumenSemanalEmail, Guid> colaEmailRepo,
+            IdentityUserManager userManager,
+            IEmailSender emailSender,
             IGuidGenerator guidGenerator,
             ILogger<NotificadorEventosService> logger)
         {
@@ -44,6 +54,10 @@ namespace AmmenTravel.BackgroundWorkers
             _eventosExternosService = eventosExternosService;
             _notificacionRepository = notificacionRepository;
             _historialRepo = historialRepo;
+            _preferenciasRepo = preferenciasRepo;
+            _colaEmailRepo = colaEmailRepo;
+            _userManager = userManager;
+            _emailSender = emailSender;
             _guidGenerator = guidGenerator;
             _logger = logger;
         }
@@ -104,21 +118,62 @@ namespace AmmenTravel.BackgroundWorkers
                             if (eventosNuevos.Any())
                             {
                                 int cantidadNuevos = eventosNuevos.Count;
+                                string titulo = $"Novedades en {destino.Nombre} 🎟️";
                                 string mensaje = cantidadNuevos == 1
                                     ? $"¡Actualización! Hay 1 evento NUEVO en {destino.Nombre}. ¡Revisalo!"
                                     : $"¡Actualización! Se agregaron {cantidadNuevos} eventos nuevos en {destino.Nombre}.";
 
-                                var notificacion = new Notificacion(
-                                    _guidGenerator.Create(),
-                                    userId,
-                                    $"Novedades en {destino.Nombre} 🎟️",
-                                    mensaje,
-                                    TipoNotificacion.Social,
-                                    "/favoritos",
-                                    "fa-ticket-alt"
-                                );
+                                // Obtenemos las preferencias del usuario (o valores por defecto)
+                                var preferencias = await _preferenciasRepo.FirstOrDefaultAsync(p => p.UserId == userId);
+                                bool enPantalla = preferencias?.EnPantalla ?? true;
+                                bool porEmail = preferencias?.PorEmail ?? true;
+                                FrecuenciaNotificacion frecuencia = preferencias?.Frecuencia ?? FrecuenciaNotificacion.Inmediata;
 
-                                await _notificacionRepository.InsertAsync(notificacion);
+                                if (frecuencia == FrecuenciaNotificacion.Inmediata)
+                                {
+                                    // === MODO INMEDIATO: todo al instante ===
+
+                                    // Campanita
+                                    if (enPantalla)
+                                    {
+                                        var notificacion = new Notificacion(
+                                            _guidGenerator.Create(),
+                                            userId,
+                                            titulo,
+                                            mensaje,
+                                            TipoNotificacion.Social,
+                                            "/favoritos",
+                                            "fa-ticket-alt"
+                                        );
+                                        await _notificacionRepository.InsertAsync(notificacion);
+                                    }
+
+                                    // Email
+                                    if (porEmail)
+                                    {
+                                        var user = await _userManager.FindByIdAsync(userId.ToString());
+                                        var email = user?.Email;
+                                        if (!string.IsNullOrEmpty(email))
+                                        {
+                                            await _emailSender.SendAsync(email, titulo, mensaje);
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    // === MODO SEMANAL: todo se encola para el domingo ===
+                                    var user = await _userManager.FindByIdAsync(userId.ToString());
+                                    var email = user?.Email ?? "";
+
+                                    var colaEmail = new ColaResumenSemanalEmail(
+                                        _guidGenerator.Create(),
+                                        userId,
+                                        email,
+                                        titulo,
+                                        mensaje
+                                    );
+                                    await _colaEmailRepo.InsertAsync(colaEmail);
+                                }
 
                                 // 5. Guardamos en la memoria los IDs nuevos para no volver a avisar mañana
                                 var nuevosRegistrosHistorial = eventosNuevos.Select(e => new HistorialNotificacionEvento(

--- a/src/AmmenTravel.Application/Workers/ResumenSemanalEmailService.cs
+++ b/src/AmmenTravel.Application/Workers/ResumenSemanalEmailService.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Volo.Abp.DependencyInjection;
+using Volo.Abp.Domain.Repositories;
+using Volo.Abp.Emailing;
+using Volo.Abp.Guids;
+using Volo.Abp.Uow;
+using AmmenTravel.Notificaciones;
+
+namespace AmmenTravel.BackgroundWorkers
+{
+    public class ResumenSemanalEmailService : ITransientDependency
+    {
+        private readonly IRepository<ColaResumenSemanalEmail, Guid> _colaEmailRepo;
+        private readonly IRepository<PreferenciasNotificacion, Guid> _preferenciasRepo;
+        private readonly IRepository<Notificacion, Guid> _notificacionRepo;
+        private readonly IEmailSender _emailSender;
+        private readonly IGuidGenerator _guidGenerator;
+        private readonly ILogger<ResumenSemanalEmailService> _logger;
+
+        public ResumenSemanalEmailService(
+            IRepository<ColaResumenSemanalEmail, Guid> colaEmailRepo,
+            IRepository<PreferenciasNotificacion, Guid> preferenciasRepo,
+            IRepository<Notificacion, Guid> notificacionRepo,
+            IEmailSender emailSender,
+            IGuidGenerator guidGenerator,
+            ILogger<ResumenSemanalEmailService> logger)
+        {
+            _colaEmailRepo = colaEmailRepo;
+            _preferenciasRepo = preferenciasRepo;
+            _notificacionRepo = notificacionRepo;
+            _emailSender = emailSender;
+            _guidGenerator = guidGenerator;
+            _logger = logger;
+        }
+
+        [UnitOfWork]
+        public virtual async Task ProcesarResumenSemanalAsync()
+        {
+            try
+            {
+                // Obtenemos todos los emails pendientes (no procesados)
+                var queryable = await _colaEmailRepo.GetQueryableAsync();
+                var emailsPendientes = await queryable
+                    .Where(e => !e.Procesado)
+                    .ToListAsync();
+
+                if (!emailsPendientes.Any())
+                {
+                    _logger.LogInformation("No hay emails pendientes en la cola de resumen semanal.");
+                    return;
+                }
+
+                // Agrupamos por usuario/email
+                var gruposPorUsuario = emailsPendientes
+                    .GroupBy(e => new { e.UserId, e.EmailDestino })
+                    .ToList();
+
+                foreach (var grupo in gruposPorUsuario)
+                {
+                    var userId = grupo.Key.UserId;
+                    var emailDestino = grupo.Key.EmailDestino;
+                    var notificaciones = grupo.ToList();
+
+                    // Leemos las preferencias actuales del usuario
+                    var preferencias = await _preferenciasRepo.FirstOrDefaultAsync(p => p.UserId == userId);
+                    bool enPantalla = preferencias?.EnPantalla ?? true;
+                    bool porEmail = preferencias?.PorEmail ?? true;
+
+                    try
+                    {
+                        // NOTIFICACIONES EN PANTALLA (campanita) - se crean ahora en el resumen
+                        if (enPantalla)
+                        {
+                            foreach (var notif in notificaciones)
+                            {
+                                var notificacion = new Notificacion(
+                                    _guidGenerator.Create(),
+                                    userId,
+                                    notif.Titulo,
+                                    notif.Mensaje,
+                                    TipoNotificacion.Social,
+                                    "/favoritos",
+                                    "fa-ticket-alt"
+                                );
+                                await _notificacionRepo.InsertAsync(notificacion);
+                            }
+                        }
+
+                        // EMAIL - solo si tiene el canal activo y hay email
+                        if (porEmail && !string.IsNullOrEmpty(emailDestino))
+                        {
+                            var htmlBody = GenerarHtmlResumen(notificaciones);
+                            await _emailSender.SendAsync(
+                                emailDestino,
+                                "🌍 Tu Resumen Semanal de AmmenTravel",
+                                htmlBody,
+                                isBodyHtml: true
+                            );
+                        }
+
+                        // Marcamos como procesados
+                        foreach (var email in notificaciones)
+                        {
+                            email.Procesado = true;
+                        }
+                        await _colaEmailRepo.UpdateManyAsync(notificaciones);
+
+                        _logger.LogInformation($"Resumen semanal procesado para usuario {userId} con {notificaciones.Count} notificaciones.");
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, $"Error al procesar resumen semanal para {emailDestino}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error general al procesar resumen semanal de emails.");
+            }
+        }
+
+        private string GenerarHtmlResumen(List<ColaResumenSemanalEmail> notificaciones)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine("<!DOCTYPE html>");
+            sb.AppendLine("<html>");
+            sb.AppendLine("<head>");
+            sb.AppendLine("<meta charset='utf-8'>");
+            sb.AppendLine("<style>");
+            sb.AppendLine("body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f5f5f5; margin: 0; padding: 20px; }");
+            sb.AppendLine(".container { max-width: 600px; margin: 0 auto; background-color: white; border-radius: 10px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); padding: 30px; }");
+            sb.AppendLine(".header { text-align: center; border-bottom: 2px solid #4CAF50; padding-bottom: 20px; margin-bottom: 20px; }");
+            sb.AppendLine(".header h1 { color: #333; margin: 0; }");
+            sb.AppendLine(".header p { color: #666; margin-top: 10px; }");
+            sb.AppendLine(".notification { background-color: #f9f9f9; border-left: 4px solid #4CAF50; padding: 15px; margin-bottom: 15px; border-radius: 0 5px 5px 0; }");
+            sb.AppendLine(".notification h3 { color: #333; margin: 0 0 8px 0; font-size: 16px; }");
+            sb.AppendLine(".notification p { color: #666; margin: 0; font-size: 14px; }");
+            sb.AppendLine(".footer { text-align: center; margin-top: 30px; padding-top: 20px; border-top: 1px solid #eee; color: #999; font-size: 12px; }");
+            sb.AppendLine(".cta-button { display: inline-block; background-color: #4CAF50; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; margin-top: 20px; }");
+            sb.AppendLine("</style>");
+            sb.AppendLine("</head>");
+            sb.AppendLine("<body>");
+            sb.AppendLine("<div class='container'>");
+
+            // Header
+            sb.AppendLine("<div class='header'>");
+            sb.AppendLine("<h1>🌍 AmmenTravel</h1>");
+            sb.AppendLine($"<p>¡Hola! Esta semana hubo <strong>{notificaciones.Count}</strong> novedades en tus destinos favoritos</p>");
+            sb.AppendLine("</div>");
+
+            // Notificaciones
+            foreach (var notif in notificaciones)
+            {
+                sb.AppendLine("<div class='notification'>");
+                sb.AppendLine($"<h3>{EscapeHtml(notif.Titulo)}</h3>");
+                sb.AppendLine($"<p>{EscapeHtml(notif.Mensaje)}</p>");
+                sb.AppendLine("</div>");
+            }
+
+            // CTA
+            sb.AppendLine("<div style='text-align: center;'>");
+            sb.AppendLine("<a href='https://ammentravel.com/favoritos' class='cta-button'>Ver mis favoritos</a>");
+            sb.AppendLine("</div>");
+
+            // Footer
+            sb.AppendLine("<div class='footer'>");
+            sb.AppendLine("<p>Recibiste este email porque activaste el resumen semanal en tu perfil.</p>");
+            sb.AppendLine("<p>© 2026 AmmenTravel - Tu compañero de viajes</p>");
+            sb.AppendLine("</div>");
+
+            sb.AppendLine("</div>");
+            sb.AppendLine("</body>");
+            sb.AppendLine("</html>");
+
+            return sb.ToString();
+        }
+
+        private string EscapeHtml(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+            return System.Net.WebUtility.HtmlEncode(text);
+        }
+    }
+}

--- a/src/AmmenTravel.Application/Workers/WorkerResumenSemanalEmails.cs
+++ b/src/AmmenTravel.Application/Workers/WorkerResumenSemanalEmails.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Volo.Abp.BackgroundWorkers;
+using Volo.Abp.Threading;
+
+namespace AmmenTravel.BackgroundWorkers
+{
+    /// <summary>
+    /// Worker que procesa el resumen semanal de emails.
+    /// Se ejecuta cada hora y verifica si es domingo entre 20:00-21:00 para enviar los resúmenes.
+    /// </summary>
+    public class WorkerResumenSemanalEmails : AsyncPeriodicBackgroundWorkerBase
+    {
+        public WorkerResumenSemanalEmails(AbpAsyncTimer timer, IServiceScopeFactory serviceScopeFactory)
+            : base(timer, serviceScopeFactory)
+        {
+            // Cada 1 hora (3600000 ms)
+            Timer.Period = 3600000;
+        }
+
+        protected override async Task DoWorkAsync(PeriodicBackgroundWorkerContext workerContext)
+        {
+            var logger = workerContext.ServiceProvider.GetRequiredService<ILogger<WorkerResumenSemanalEmails>>();
+            
+            // Verificamos si es el momento correcto: Domingo entre 20:00 y 21:00
+            var ahora = DateTime.Now;
+            
+            if (ahora.DayOfWeek == DayOfWeek.Sunday && ahora.Hour == 20)
+            {
+                logger.LogInformation("¡Es domingo a las 20hs! Ejecutando envío de resumen semanal...");
+                
+                var resumenService = workerContext.ServiceProvider.GetRequiredService<ResumenSemanalEmailService>();
+                await resumenService.ProcesarResumenSemanalAsync();
+                
+                logger.LogInformation("Resumen semanal completado.");
+            }
+            else
+            {
+                logger.LogDebug($"No es momento de resumen semanal. Actual: {ahora.DayOfWeek} {ahora.Hour}:00");
+            }
+        }
+    }
+}

--- a/src/AmmenTravel.Domain.Shared/Notificaciones/FrecuenciaNotificacion.cs
+++ b/src/AmmenTravel.Domain.Shared/Notificaciones/FrecuenciaNotificacion.cs
@@ -1,0 +1,8 @@
+namespace AmmenTravel.Notificaciones
+{
+    public enum FrecuenciaNotificacion
+    {
+        Inmediata = 0,
+        ResumenSemanal = 1
+    }
+}

--- a/src/AmmenTravel.Domain/AmmenTravelDomainModule.cs
+++ b/src/AmmenTravel.Domain/AmmenTravelDomainModule.cs
@@ -1,6 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using AmmenTravel.Localization;
 using AmmenTravel.MultiTenancy;
 using Volo.Abp.Localization;
 using Volo.Abp.Modularity;
@@ -42,9 +40,5 @@ public class AmmenTravelDomainModule : AbpModule
             options.IsEnabled = MultiTenancyConsts.IsEnabled;
         });
 
-
-#if DEBUG
-        context.Services.Replace(ServiceDescriptor.Singleton<IEmailSender, NullEmailSender>());
-#endif
     }
 }

--- a/src/AmmenTravel.Domain/AmmenTravelDomainModule.cs
+++ b/src/AmmenTravel.Domain/AmmenTravelDomainModule.cs
@@ -44,9 +44,7 @@ public class AmmenTravelDomainModule : AbpModule
 
 
 #if DEBUG
-        // NullEmailSender desactivado para permitir envío de emails reales.
-        // Si querés volver a desactivar emails en desarrollo, descomentá la línea:
-        // context.Services.Replace(ServiceDescriptor.Singleton<IEmailSender, NullEmailSender>());
+        context.Services.Replace(ServiceDescriptor.Singleton<IEmailSender, NullEmailSender>());
 #endif
     }
 }

--- a/src/AmmenTravel.Domain/AmmenTravelDomainModule.cs
+++ b/src/AmmenTravel.Domain/AmmenTravelDomainModule.cs
@@ -44,7 +44,9 @@ public class AmmenTravelDomainModule : AbpModule
 
 
 #if DEBUG
-        context.Services.Replace(ServiceDescriptor.Singleton<IEmailSender, NullEmailSender>());
+        // NullEmailSender desactivado para permitir envío de emails reales.
+        // Si querés volver a desactivar emails en desarrollo, descomentá la línea:
+        // context.Services.Replace(ServiceDescriptor.Singleton<IEmailSender, NullEmailSender>());
 #endif
     }
 }

--- a/src/AmmenTravel.Domain/Notificaciones/ColaResumenSemanalEmail.cs
+++ b/src/AmmenTravel.Domain/Notificaciones/ColaResumenSemanalEmail.cs
@@ -1,0 +1,30 @@
+using System;
+using Volo.Abp.Domain.Entities.Auditing;
+
+namespace AmmenTravel.Notificaciones
+{
+    /// <summary>
+    /// Cola de emails pendientes para el resumen semanal.
+    /// Se procesan por un worker semanal que los agrupa por usuario.
+    /// </summary>
+    public class ColaResumenSemanalEmail : CreationAuditedEntity<Guid>
+    {
+        public Guid UserId { get; set; }
+        public string EmailDestino { get; set; }
+        public string Titulo { get; set; }
+        public string Mensaje { get; set; }
+        public bool Procesado { get; set; }
+
+        protected ColaResumenSemanalEmail() { } // Constructor para EF Core
+
+        public ColaResumenSemanalEmail(Guid id, Guid userId, string emailDestino, string titulo, string mensaje)
+            : base(id)
+        {
+            UserId = userId;
+            EmailDestino = emailDestino;
+            Titulo = titulo;
+            Mensaje = mensaje;
+            Procesado = false;
+        }
+    }
+}

--- a/src/AmmenTravel.Domain/Notificaciones/PreferenciasNotificacion.cs
+++ b/src/AmmenTravel.Domain/Notificaciones/PreferenciasNotificacion.cs
@@ -1,0 +1,30 @@
+using System;
+using Volo.Abp.Domain.Entities;
+
+namespace AmmenTravel.Notificaciones
+{
+    /// <summary>
+    /// Preferencias de notificación del usuario.
+    /// Relación 1:1 con el usuario de Identity.
+    /// Si no existe registro para un usuario, se asumen valores por defecto:
+    /// EnPantalla = true, PorEmail = true, Frecuencia = Inmediata
+    /// </summary>
+    public class PreferenciasNotificacion : Entity<Guid>
+    {
+        public Guid UserId { get; set; }
+        public bool EnPantalla { get; set; }
+        public bool PorEmail { get; set; }
+        public FrecuenciaNotificacion Frecuencia { get; set; }
+
+        protected PreferenciasNotificacion() { } // Constructor para EF Core
+
+        public PreferenciasNotificacion(Guid id, Guid userId, bool enPantalla = true, bool porEmail = true, FrecuenciaNotificacion frecuencia = FrecuenciaNotificacion.Inmediata)
+            : base(id)
+        {
+            UserId = userId;
+            EnPantalla = enPantalla;
+            PorEmail = porEmail;
+            Frecuencia = frecuencia;
+        }
+    }
+}

--- a/src/AmmenTravel.EntityFrameworkCore/EntityFrameworkCore/AmmenTravelDbContext.cs
+++ b/src/AmmenTravel.EntityFrameworkCore/EntityFrameworkCore/AmmenTravelDbContext.cs
@@ -41,6 +41,8 @@ public class AmmenTravelDbContext :
     public DbSet<Notificacion> Notificaciones { get; set; }
 
     public DbSet<HistorialNotificacionEvento> HistorialNotificacionesEventos { get; set; }
+    public DbSet<PreferenciasNotificacion> PreferenciasNotificaciones { get; set; }
+    public DbSet<ColaResumenSemanalEmail> ColaResumenSemanalEmails { get; set; }
 
 
     #region Entities from the modules
@@ -58,13 +60,13 @@ public class AmmenTravelDbContext :
 
     #endregion
 
-    // Hacemos nullable para poder tener un constructor solo con DbContextOptions (diseño/migraciones)
+    // Hacemos nullable para poder tener un constructor solo con DbContextOptions (diseï¿½o/migraciones)
     private readonly ICurrentUser? _currentUser;
 
     // Propiedad de instancia usada por el HasQueryFilter (permite cambiar por instancia de DbContext)
     private Guid? CurrentUserId { get; set; }
 
-    // Constructor principal usado en runtime (inyección de ICurrentUser)
+    // Constructor principal usado en runtime (inyecciï¿½n de ICurrentUser)
     public AmmenTravelDbContext(DbContextOptions<AmmenTravelDbContext> options, ICurrentUser currentUser)
         : base(options)
     {
@@ -72,7 +74,7 @@ public class AmmenTravelDbContext :
         CurrentUserId = _currentUser?.Id;
     }
 
-    // Constructor adicional para tiempo de diseño / migraciones (IDesignTimeDbContextFactory)
+    // Constructor adicional para tiempo de diseï¿½o / migraciones (IDesignTimeDbContextFactory)
     // Deja _currentUser nulo y CurrentUserId a null para evitar dependencias en el factory.
     public AmmenTravelDbContext(DbContextOptions<AmmenTravelDbContext> options)
         : base(options)
@@ -85,7 +87,7 @@ public class AmmenTravelDbContext :
     {
         base.OnModelCreating(builder);
 
-        /* Configuración de módulos ABP */
+        /* Configuraciï¿½n de mï¿½dulos ABP */
         builder.ConfigurePermissionManagement();
         builder.ConfigureSettingManagement();
         builder.ConfigureBackgroundJobs();
@@ -95,7 +97,7 @@ public class AmmenTravelDbContext :
         builder.ConfigureOpenIddict();
         builder.ConfigureBlobStoring();
 
-        /* Configuración de tus entidades */
+        /* Configuraciï¿½n de tus entidades */
         builder.Entity<DestinoTuristico>(b =>
         {
             b.ToTable(AmmenTravelConsts.DbTablePrefix + "Destinos", AmmenTravelConsts.DbSchema);
@@ -119,38 +121,38 @@ public class AmmenTravelDbContext :
             b.Property(x => x.UserId).IsRequired();
 
             // --- AGREGAR ESTO ---
-            // Define la relación explícita: Una Opinión tiene UN Destino
+            // Define la relaciï¿½n explï¿½cita: Una Opiniï¿½n tiene UN Destino
             b.HasOne(x => x.DestinoTuristico)
-             .WithMany() // Un destino puede tener muchas opiniones (aunque no esté en la clase Destino)
+             .WithMany() // Un destino puede tener muchas opiniones (aunque no estï¿½ en la clase Destino)
              .HasForeignKey(x => x.DestinoTuristicoId)
-             .OnDelete(DeleteBehavior.Cascade); // O Restrict, según prefieras
+             .OnDelete(DeleteBehavior.Cascade); // O Restrict, segï¿½n prefieras
         });
 
-        /* Configuración de LISTA DE FAVORITOS (Contenedor) */
+        /* Configuraciï¿½n de LISTA DE FAVORITOS (Contenedor) */
         builder.Entity<ListaFavorito>(b =>
         {
             b.ToTable(AmmenTravelConsts.DbTablePrefix + "ListasFavoritos", AmmenTravelConsts.DbSchema);
             b.ConfigureByConvention();
-            // Como es única por usuario, EF ya usa el UserId por la interfaz IUserOwned
+            // Como es ï¿½nica por usuario, EF ya usa el UserId por la interfaz IUserOwned
         });
 
-        /* Configuración de LINEAS DE FAVORITOS */
+        /* Configuraciï¿½n de LINEAS DE FAVORITOS */
         builder.Entity<LineaListaFavorito>(b =>
         {
             b.ToTable(AmmenTravelConsts.DbTablePrefix + "LineasListasFavoritos", AmmenTravelConsts.DbSchema);
             b.ConfigureByConvention();
 
-            // RELACIÓN 1: Una línea pertenece a UNA Lista
+            // RELACIï¿½N 1: Una lï¿½nea pertenece a UNA Lista
             b.HasOne(x => x.ListaFavorito)
-                .WithMany() // Una lista tiene muchas líneas (aunque no lo definamos en la clase Lista, EF lo entiende)
+                .WithMany() // Una lista tiene muchas lï¿½neas (aunque no lo definamos en la clase Lista, EF lo entiende)
                 .HasForeignKey(x => x.ListaFavoritoId)
-                .OnDelete(DeleteBehavior.Cascade); // IMPORTANTE: Si un día borras la lista, se borran las líneas.
+                .OnDelete(DeleteBehavior.Cascade); // IMPORTANTE: Si un dï¿½a borras la lista, se borran las lï¿½neas.
 
-            // RELACIÓN 2: Una línea apunta a UN Destino
+            // RELACIï¿½N 2: Una lï¿½nea apunta a UN Destino
             b.HasOne(x => x.DestinoTuristico)
                 .WithMany()
                 .HasForeignKey(x => x.DestinoTuristicoId)
-                .OnDelete(DeleteBehavior.Cascade); // Si borras el destino (ej. París), desaparece de los favoritos de todos.
+                .OnDelete(DeleteBehavior.Cascade); // Si borras el destino (ej. Parï¿½s), desaparece de los favoritos de todos.
         });
 
         builder.Entity<Experiencia>(b =>
@@ -186,8 +188,29 @@ public class AmmenTravelDbContext :
 
             b.Property(x => x.EventoTicketmasterId).IsRequired().HasMaxLength(100);
 
-            // Índice compuesto fundamental para que el worker vuele buscando coincidencias
+            // ï¿½ndice compuesto fundamental para que el worker vuele buscando coincidencias
             b.HasIndex(x => new { x.UserId, x.DestinoTuristicoId });
+        });
+        builder.Entity<PreferenciasNotificacion>(b =>
+        {
+            b.ToTable(AmmenTravelConsts.DbTablePrefix + "PreferenciasNotificaciones", AmmenTravelConsts.DbSchema);
+            b.ConfigureByConvention();
+
+            // Ãndice Ãºnico para relaciÃ³n 1:1 con usuario
+            b.HasIndex(x => x.UserId).IsUnique();
+        });
+
+        builder.Entity<ColaResumenSemanalEmail>(b =>
+        {
+            b.ToTable(AmmenTravelConsts.DbTablePrefix + "ColaResumenSemanalEmails", AmmenTravelConsts.DbSchema);
+            b.ConfigureByConvention();
+
+            b.Property(x => x.EmailDestino).IsRequired().HasMaxLength(256);
+            b.Property(x => x.Titulo).IsRequired().HasMaxLength(200);
+            b.Property(x => x.Mensaje).IsRequired().HasMaxLength(2000);
+
+            // Ãndice para procesar eficientemente por usuario y estado
+            b.HasIndex(x => new { x.UserId, x.Procesado });
         });
 
         /* Filtro global para entidades que implementen IUserOwned */

--- a/src/AmmenTravel.EntityFrameworkCore/Migrations/20260302235920_AgregaPreferenciasUsuario.Designer.cs
+++ b/src/AmmenTravel.EntityFrameworkCore/Migrations/20260302235920_AgregaPreferenciasUsuario.Designer.cs
@@ -4,17 +4,20 @@ using AmmenTravel.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
 #nullable disable
 
-namespace AmmenTravel.src.AmmenTravel.EntityFrameworkCore.Migrations
+namespace AmmenTravel.Migrations
 {
     [DbContext(typeof(AmmenTravelDbContext))]
-    partial class AmmenTravelDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260302235920_AgregaPreferenciasUsuario")]
+    partial class AgregaPreferenciasUsuario
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -296,47 +299,6 @@ namespace AmmenTravel.src.AmmenTravel.EntityFrameworkCore.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("AppListasFavoritos", (string)null);
-                });
-
-            modelBuilder.Entity("AmmenTravel.Notificaciones.ColaResumenSemanalEmail", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime>("CreationTime")
-                        .HasColumnType("datetime2")
-                        .HasColumnName("CreationTime");
-
-                    b.Property<Guid?>("CreatorId")
-                        .HasColumnType("uniqueidentifier")
-                        .HasColumnName("CreatorId");
-
-                    b.Property<string>("EmailDestino")
-                        .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
-
-                    b.Property<string>("Mensaje")
-                        .IsRequired()
-                        .HasMaxLength(2000)
-                        .HasColumnType("nvarchar(2000)");
-
-                    b.Property<bool>("Procesado")
-                        .HasColumnType("bit");
-
-                    b.Property<string>("Titulo")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("UserId", "Procesado");
-
-                    b.ToTable("AppColaResumenSemanalEmails", (string)null);
                 });
 
             modelBuilder.Entity("AmmenTravel.Notificaciones.HistorialNotificacionEvento", b =>

--- a/src/AmmenTravel.EntityFrameworkCore/Migrations/20260302235920_AgregaPreferenciasUsuario.cs
+++ b/src/AmmenTravel.EntityFrameworkCore/Migrations/20260302235920_AgregaPreferenciasUsuario.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AmmenTravel.Migrations
+{
+    /// <inheritdoc />
+    public partial class AgregaPreferenciasUsuario : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AppPreferenciasNotificaciones",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EnPantalla = table.Column<bool>(type: "bit", nullable: false),
+                    PorEmail = table.Column<bool>(type: "bit", nullable: false),
+                    Frecuencia = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppPreferenciasNotificaciones", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppPreferenciasNotificaciones_UserId",
+                table: "AppPreferenciasNotificaciones",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppPreferenciasNotificaciones");
+        }
+    }
+}

--- a/src/AmmenTravel.EntityFrameworkCore/Migrations/20260303000955_AgregaColaResumenSemanal.Designer.cs
+++ b/src/AmmenTravel.EntityFrameworkCore/Migrations/20260303000955_AgregaColaResumenSemanal.Designer.cs
@@ -4,17 +4,20 @@ using AmmenTravel.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 
 #nullable disable
 
-namespace AmmenTravel.src.AmmenTravel.EntityFrameworkCore.Migrations
+namespace AmmenTravel.Migrations
 {
     [DbContext(typeof(AmmenTravelDbContext))]
-    partial class AmmenTravelDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260303000955_AgregaColaResumenSemanal")]
+    partial class AgregaColaResumenSemanal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AmmenTravel.EntityFrameworkCore/Migrations/20260303000955_AgregaColaResumenSemanal.cs
+++ b/src/AmmenTravel.EntityFrameworkCore/Migrations/20260303000955_AgregaColaResumenSemanal.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AmmenTravel.Migrations
+{
+    /// <inheritdoc />
+    public partial class AgregaColaResumenSemanal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AppColaResumenSemanalEmails",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    EmailDestino = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    Titulo = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Mensaje = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: false),
+                    Procesado = table.Column<bool>(type: "bit", nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppColaResumenSemanalEmails", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppColaResumenSemanalEmails_UserId_Procesado",
+                table: "AppColaResumenSemanalEmails",
+                columns: new[] { "UserId", "Procesado" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppColaResumenSemanalEmails");
+        }
+    }
+}

--- a/src/AmmenTravel.HttpApi.Host/appsettings.json
+++ b/src/AmmenTravel.HttpApi.Host/appsettings.json
@@ -22,5 +22,15 @@
   "Ticketmaster": {
     "BaseUrl": "https://app.ticketmaster.com/discovery/v2/",
     "ApiKey": "511GGURumNYi0BrpfhJfI13FdFj3ryTE"
+  },
+  "Settings": {
+    "Abp.Mailing.Smtp.Host": "smtp.gmail.com",
+    "Abp.Mailing.Smtp.Port": "587",
+    "Abp.Mailing.Smtp.UserName": "tinedsolutions@gmail.com",
+    "Abp.Mailing.Smtp.Password": "amxk lrrh iftk xsug",
+    "Abp.Mailing.Smtp.EnableSsl": "true",
+    "Abp.Mailing.Smtp.UseDefaultCredentials": "false",
+    "Abp.Mailing.DefaultFromAddress": "tinedsolutions@gmail.com",
+    "Abp.Mailing.DefaultFromDisplayName": "AmmenTravel"
   }
 }

--- a/src/AmmenTravel.HttpApi/Controllers/FotoPerfilController.cs
+++ b/src/AmmenTravel.HttpApi/Controllers/FotoPerfilController.cs
@@ -69,7 +69,8 @@ namespace AmmenTravel.Controllers
             }
 
             var bytes = await _contenedorBlob.GetAllBytesAsync(nombreBlob);
-            return File(bytes, "image/jpeg");
+            var contentType = DetectarMimeType(bytes);
+            return File(bytes, contentType);
         }
 
         [HttpGet]
@@ -78,6 +79,32 @@ namespace AmmenTravel.Controllers
         {
             if (!_usuarioActual.IsAuthenticated) return Unauthorized();
             return await ObtenerAsync(_usuarioActual.Id.Value);
+        }
+
+        private static string DetectarMimeType(byte[] bytes)
+        {
+            if (bytes.Length >= 4)
+            {
+                // PNG: 89 50 4E 47
+                if (bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47)
+                    return "image/png";
+
+                // GIF: 47 49 46 38
+                if (bytes[0] == 0x47 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x38)
+                    return "image/gif";
+
+                // WebP: 52 49 46 46 ... 57 45 42 50
+                if (bytes.Length >= 12 &&
+                    bytes[0] == 0x52 && bytes[1] == 0x49 && bytes[2] == 0x46 && bytes[3] == 0x46 &&
+                    bytes[8] == 0x57 && bytes[9] == 0x45 && bytes[10] == 0x42 && bytes[11] == 0x50)
+                    return "image/webp";
+            }
+
+            // JPEG: FF D8 FF
+            if (bytes.Length >= 3 && bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF)
+                return "image/jpeg";
+
+            return "image/jpeg"; // fallback
         }
     }
 }


### PR DESCRIPTION
## Resumen

Esta rama extiende `feature/17-API-Eventos` con tres bloques de funcionalidad nuevos: **preferencias de notificación por usuario**, **envío real de emails**, y la **corrección del bug de fotos de perfil compartidas**.

---

## Commits exclusivos de esta rama (respecto de feature/17-API-Eventos)

| Fecha | Commit | Descripción |
|-------|--------|-------------|
| 03-03 | `e6688c5` | Preferencias de notificación completas (backend + lógica) |
| 04-03 | `38ef01b` | Integración de preferencias en el perfil personalizado UI |
| 04-03 | `dcc8f85` | Envío de emails con plantillas HTML y configuración SMTP |
| 06-03 | `7eba57f` | Fix crítico: fotos de perfil individuales por usuario |

---

## Detalle de cambios

### 1. Preferencias de notificación por usuario

Se implementó un sistema completo para que cada usuario pueda configurar cómo quiere recibir notificaciones:

- **Backend:** nuevo endpoint y lógica de dominio para guardar/recuperar preferencias (`enPantalla`, `porEmail`, `frecuencia`: inmediata o resumen semanal).
- **Frontend:** sección de preferencias integrada directamente en la pantalla de **Mi Perfil Personalizado**, con campos para activar notificaciones en pantalla, por email y configurar la frecuencia.
- Las preferencias se persisten por usuario en la base de datos y se respetan en el momento de disparar cada notificación.

### 2. Envío de emails con plantillas HTML

Se implementó el envío real de correos electrónicos para todas las notificaciones existentes:

- **Configuración SMTP** integrada via `appsettings.json` (Gmail + contraseña de aplicación).
- **Plantillas HTML** responsivas para cada tipo de notificación (eventos en favoritos, cambios en destinos, etc.).
- El envío se gatilla automáticamente cuando la preferencia `porEmail` del usuario está activa.
- Se respeta también la preferencia de `frecuencia`: si es `ResumenSemanal`, las notificaciones se acumulan; si es `Inmediata`, se envían al momento.

### 3. Fix crítico: fotos de perfil individuales por usuario

Se corrigió un bug donde **cambiar la foto de perfil de un usuario la sobreescribía para todos**.

**Causa raíz:** el servicio `foto-perfil.service.ts` guardaba todas las fotos bajo la clave fija `'foto-perfil-usuario'` en `localStorage`. Cualquier usuario que abriera la app veía la foto del último que la actualizó.

**Solución aplicada:**

- `services/foto-perfil.service.ts`: eliminada toda la lógica de `localStorage`. Ahora construye URLs al endpoint real del backend por `userId` (`/api/app/foto-perfil/obtener/{userId}`). Esto corrige la visualización en el **navbar** y en la **Comunidad de Viajeros** sin necesidad de tocar esos componentes.
- `mi-perfil-personalizado.component.ts`: la subida de foto ahora hace `POST /api/app/foto-perfil/subir` con `FormData` via `RestService`, apuntando directamente al backend. 
- `FotoPerfilController.cs`: se agregó detección dinámica del MIME type al servir imágenes usando magic bytes (detecta PNG, GIF, WebP y JPEG) en lugar de devolver siempre `image/jpeg`, lo que podía corromper imágenes de otros formatos.
- Se eliminó el `?t=timestamp` del servicio global para evitar que el navegador hiciera N requests simultáneas a la base de datos (una por cada viajero en la lista), lo que saturaba el connection pool de SQL Express. El cache-buster se conserva únicamente en el perfil personalizado para refrescar la imagen inmediatamente tras subirla.

---

## Áreas de la aplicación afectadas

- ✅ **Mi Perfil Personalizado** — preferencias, foto de perfil, subida al servidor
- ✅ **Navbar / Avatar** — foto correcta por usuario
- ✅ **Comunidad de Viajeros** — foto individual por cada viajero
- ✅ **Sistema de notificaciones** — respeta preferencias, envía emails reales
- ✅ **Backend** — endpoints de foto, SMTP, preferencias

---

## Dependencias

Esta rama incluye todos los commits de `feature/17-API-Eventos` (integración TicketMaster, worker de eventos, notificaciones en favoritos). El PR puede mergearse a `main` de forma independiente.